### PR TITLE
j8y18lte: uprev hal drm.clearkey & drm.widevine to 1.3

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -258,8 +258,8 @@ PRODUCT_COPY_FILES += \
 PRODUCT_PACKAGES += \
     android.hardware.drm@1.0-impl \
     android.hardware.drm@1.0-service \
-    android.hardware.drm@1.2-service.clearkey \
-    android.hardware.drm@1.2-service.widevine 
+    android.hardware.drm@1.3-service.clearkey \
+    android.hardware.drm@1.3-service.widevine
 
 # Memory
 PRODUCT_PACKAGES += \


### PR DESCRIPTION

fixes Error:
 W HidlServiceManagement: Waited one second for android.hardware.drm@1.0::IDrmFactory/clearkey
 I hwservicemanager: Since android.hardware.drm@1.0::IDrmFactory/clearkey is not registered, trying to start it as a lazy HAL.
 I HidlServiceManagement: getService: Trying again for android.hardware.drm@1.0::IDrmFactory/clearkey...
 I [5:           init:    1] init: starting service 'vendor.drm-clearkey-hal-1-2'...
 I [7:           init:    1] init: Control message: Processed ctl.interface_start for 'android.hardware.drm@1.0::IDrmFactory/clearkey' from pid: 437 (/system/bin/hwservicemanager)
 I hwservicemanager: getTransport: Cannot find entry android.hardware.drm@1.3::IDrmFactory/clearkey in either framework or device manifest.
 E HidlServiceManagement: Service android.hardware.drm@1.3::IDrmFactory/clearkey must be in VINTF manifest in order to register/get.
 F android.hardware.drm@1.2-service.clearkey: Check failed: drmFactory->registerAsService("clearkey") == android::NO_ERROR (drmFactory->registerAsService("clearkey")=-2147483648, android::NO_ERROR=0) Failed to register Clearkey Factory HAL
 F libc    : Fatal signal 6 (SIGABRT), code -1 (SI_QUEUE) in tid 14062 (android.hardwar), pid 14062 (android.hardwar)
 I crash_dump32: obtaining output fd from tombstoned, type: kDebuggerdTombstone
 I tombstoned: received crash request for pid 14062
 I crash_dump32: performing dump of process 14062 (target tid = 14062)
 F DEBUG   : *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** ***
 F DEBUG   : LineageOS Version: '18.0-20220915-UNOFFICIAL-j8y18lte'
 F DEBUG   : Build fingerprint: 'samsung/j8y18ltedd/j8y18lte:10/QP1A.190711.020/J810GDDU6CUI1:user/release-keys'
 F DEBUG   : Revision: '4'
 F DEBUG   : ABI: 'arm'
 F DEBUG   : Timestamp: 2022-09-16 06:36:34+0530
 F DEBUG   : pid: 14062, tid: 14062, name: android.hardwar  >>> /vendor/bin/hw/android.hardware.drm@1.2-service.clearkey <<<
 F DEBUG   : uid: 1013
 F DEBUG   : signal 6 (SIGABRT), code -1 (SI_QUEUE), fault addr --------
 F DEBUG   : Abort message: 'Check failed: drmFactory->registerAsService("clearkey") == android::NO_ERROR (drmFactory->registerAsService("clearkey")=-2147483648, android::NO_ERROR=0) Failed to register Clearkey Factory HAL'
 F DEBUG   :     r0  00000000  r1  000036ee  r2  00000006  r3  ffcdc1e0
 F DEBUG   :     r4  ffcdc1f4  r5  ffcdc1d8  r6  000036ee  r7  0000016b
 F DEBUG   :     r8  ffcdc1e0  r9  ffcdc1f0  r10 ffcdc210  r11 ffcdc200
 F DEBUG   :     ip  000036ee  sp  ffcdc1b0  lr  f3a7b3cd  pc  f3a7b3e0
 F DEBUG   : backtrace:
 F DEBUG   :       #00 pc 000383e0  /apex/com.android.runtime/lib/bionic/libc.so (abort+172) (BuildId: ff3572bcdeec7686433dac68a828d67d)
 F DEBUG   :       #01 pc 00004bdb  /system/lib/liblog.so (__android_log_default_aborter+6) (BuildId: d727e766119ae85ec8c6bb2ba9c47795)
 F DEBUG   :       #02 pc 0000d2b3  /system/lib/libbase.so (android::base::LogMessage::~LogMessage()+222) (BuildId: ea511d58bb5f30bf6cfdfa9e128735a0)
 F DEBUG   :       #03 pc 00015c3d  /vendor/bin/hw/android.hardware.drm@1.2-service.clearkey (main+604) (BuildId: 6cd7288bd76e982fddc5fd6065723cac)
 F DEBUG   :       #04 pc 00032c9d  /apex/com.android.runtime/lib/bionic/libc.so (__libc_init+68) (BuildId: ff3572bcdeec7686433dac68a828d67d)

Signed-off-by: Ayush Bisht <ayushbisht5663@gmail.com>